### PR TITLE
fix(write): Make it write the output to dest, not src

### DIFF
--- a/tasks/ngmin.js
+++ b/tasks/ngmin.js
@@ -11,11 +11,11 @@ module.exports = function (grunt) {
     })));
 
     this.files.forEach(function (file) {
-      file.src.forEach(function (file) {
-        var content = grunt.file.read(file);
-        content = ngmin.annotate(content);
-        grunt.file.write(file, content);
-      });
+      var contents = file.src
+        .map(grunt.file.read)
+        .map(ngmin.annotate)
+        .join('');
+      grunt.file.write(file.dest, contents);
     });
 
   });


### PR DESCRIPTION
Before, the task would write the output files back to the source files, instead of the destination.

Now it compiles all the source files and then writes them to the dest.  With fancier happy `array.map()`.

I tested it some on my own, seems to work. 
