### PR TITLE
Adds necessary keyword for plugin to be included in Gruntjs.com website

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "keywords": [
     "grunt",
+    "gruntplugin",
     "angular",
     "angularjs",
     "minify"


### PR DESCRIPTION
As stated on http://gruntjs.com/plugins:

In order for a Grunt plugin to be listed here, it must be published on npm with the gruntplugin keyword.
