### PR TITLE
Only log the list of all files when the --verbose option was specified

### DIFF
--- a/tasks/ngmin.js
+++ b/tasks/ngmin.js
@@ -6,9 +6,11 @@ module.exports = function (grunt) {
 
   grunt.registerMultiTask('ngmin', 'Annotate AngularJS scripts for minification', function () {
 
-    grunt.log.writeln('ngminifying ' + grunt.log.wordlist(this.files.map(function (file) {
+    grunt.verbose.writeln('ngminifying ' + grunt.log.wordlist(this.files.map(function (file) {
       return file.src;
     })));
+
+    grunt.verbose.or.writeln('ngminifying ' + this.files.length + ' file(s)');
 
     this.files.forEach(function (file) {
       var contents = file.src


### PR DESCRIPTION
Currently the list of all files is logged during the build and this is not configurable. In large projects this creates a huge log statement, but i think this information is only useful when somenthing goes wrong.
